### PR TITLE
edit the behavior of the configuration link for iOS and MacOS

### DIFF
--- a/src/_includes/components/how-to-use.njk
+++ b/src/_includes/components/how-to-use.njk
@@ -89,8 +89,8 @@
           </li>
           <li>
             You can download configuration for
-            <a href="/apple/puredns-https.mobileconfig">DoH</a> and/or
-            <a href="/apple/puredns-tls.mobileconfig">DoT</a>.
+            <a href="/apple/puredns-https.mobileconfig" download target="_blank">DoH</a> and/or
+            <a href="/apple/puredns-tls.mobileconfig" download target="_blank">DoT</a>.
           </li>
           <li>
             Go to <strong>Settings → General → VPN & Device Mangement</strong>
@@ -374,8 +374,8 @@ Add-DnsClientDohServerAddress -ServerAddress {{ ipv4_2 }} -DohTemplate https://{
           </li>
           <li>
             You can download configuration for
-            <a href="/apple/puredns-https.mobileconfig">DoH</a> and/or
-            <a href="/apple/puredns-tls.mobileconfig">DoT</a>.
+            <a href="/apple/puredns-https.mobileconfig" download target="_blank">DoH</a> and/or
+            <a href="/apple/puredns-tls.mobileconfig" download target="_blank">DoT</a>.
           </li>
           <li>Open the downloaded <strong>.mobileconfig</strong> file.</li>
           <li>Open <strong>System Preferences</strong>.</li>


### PR DESCRIPTION
edit the behavior of the configuration link for iOS and MacOS to force download instead of opening the file itself in the browser.

Before, it requires the user to right click and 'Save as' to download the config itself